### PR TITLE
Refactor read/writes to Command Pattern with simple executor

### DIFF
--- a/lib/src/main/java/edu/touro/mco152/bm/AppBenchmarkSettings.java
+++ b/lib/src/main/java/edu/touro/mco152/bm/AppBenchmarkSettings.java
@@ -31,4 +31,8 @@ public class AppBenchmarkSettings implements BenchmarkSettings {
     @Override public void incrementNextMarkNumber() { App.nextMarkNumber += App.numOfMarks; }
     @Override public void setIdleState() { App.state = App.State.IDLE_STATE; }
     @Override public void message(String message) { App.msg(message);}
+    @Override
+    public void setNextMarkNumber(int newNextMarkNumber) {
+        App.nextMarkNumber = newNextMarkNumber;
+    }
 }

--- a/lib/src/main/java/edu/touro/mco152/bm/BenchmarkSettings.java
+++ b/lib/src/main/java/edu/touro/mco152/bm/BenchmarkSettings.java
@@ -30,4 +30,7 @@ public interface BenchmarkSettings {
     void incrementNextMarkNumber();
     void setIdleState();
     void message(String message);
+
+    //added for command usage
+    void setNextMarkNumber(int newNextMarkNumber);
 }

--- a/lib/src/main/java/edu/touro/mco152/bm/DiskMark.java
+++ b/lib/src/main/java/edu/touro/mco152/bm/DiskMark.java
@@ -6,7 +6,6 @@ import java.text.DecimalFormat;
  * Tracks and records progress as a disk read or write is being executed
  */
 public class DiskMark {
-
     static DecimalFormat df = new DecimalFormat("###.###");
     MarkType type;
     private int markNum = 0;       // x-axis
@@ -14,7 +13,7 @@ public class DiskMark {
     private double cumMin = 0;
     private double cumMax = 0;
     private double cumAvg = 0;
-    DiskMark(MarkType type) {
+    public DiskMark(MarkType type) {
         this.type = type;
     }
 
@@ -23,7 +22,7 @@ public class DiskMark {
         return "Mark(" + type + "): " + getMarkNum() + " bwMbSec: " + getBwMbSecAsString() + " avg: " + getAvgAsString();
     }
 
-    String getBwMbSecAsString() {
+    public String getBwMbSecAsString() {
         return df.format(getBwMbSec());
     }
 

--- a/lib/src/main/java/edu/touro/mco152/bm/DiskWorker.java
+++ b/lib/src/main/java/edu/touro/mco152/bm/DiskWorker.java
@@ -1,21 +1,8 @@
 package edu.touro.mco152.bm;
 
-import edu.touro.mco152.bm.persist.DiskRun;
-import edu.touro.mco152.bm.persist.EM;
-
-import jakarta.persistence.EntityManager;
 import javax.swing.*;
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.io.RandomAccessFile;
-import java.util.Date;
 import java.util.List;
-import java.util.logging.Level;
 import java.util.logging.Logger;
-
-import static edu.touro.mco152.bm.DiskMark.MarkType.READ;
-import static edu.touro.mco152.bm.DiskMark.MarkType.WRITE;
 
 /**
  * Run the disk benchmarking as a Swing-compliant thread (only one of these threads can run at

--- a/lib/src/main/java/edu/touro/mco152/bm/GeneralUsageBenchmarker.java
+++ b/lib/src/main/java/edu/touro/mco152/bm/GeneralUsageBenchmarker.java
@@ -1,24 +1,14 @@
 package edu.touro.mco152.bm;
 
-import edu.touro.mco152.bm.persist.DiskRun;
-import edu.touro.mco152.bm.persist.EM;
-import jakarta.persistence.EntityManager;
+import edu.touro.mco152.bm.commands.*;
 
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.io.RandomAccessFile;
-import java.util.Date;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-
-import static edu.touro.mco152.bm.DiskMark.MarkType.READ;
-import static edu.touro.mco152.bm.DiskMark.MarkType.WRITE;
 
 public class GeneralUsageBenchmarker implements Benchmarker {
     @Override
     public boolean runBenchmark(BenchmarkSettings settings, GeneralUI ui, DiskWorker worker) throws Exception{
-        File testFile = null;
+
          /*
           We 'got here' because: 1: End-user clicked 'Start' on the benchmark UI,
           which triggered the start-benchmark event associated with the App::startBenchmark()
@@ -31,24 +21,6 @@ public class GeneralUsageBenchmarker implements Benchmarker {
         settings.message("num files: " + settings.getNumOfMarks() + ", num blks: " + settings.getNumOfBlocks()
                 + ", blk size (kb): " + settings.getBlockSizeKb() + ", blockSequence: " + settings.getBlockSequence());
 
-        /*
-          init local vars that keep track of benchmarks, and a large read/write buffer
-         */
-        int wUnitsComplete = 0, rUnitsComplete = 0, unitsComplete;
-        int wUnitsTotal = settings.isWriteTest() ? settings.getNumOfBlocks() * settings.getNumOfMarks() : 0;
-        int rUnitsTotal = settings.isReadTest() ? settings.getNumOfBlocks() * settings.getNumOfMarks() : 0;
-        int unitsTotal = wUnitsTotal + rUnitsTotal;
-        float percentComplete;
-
-        int blockSize = settings.getBlockSizeKb() * settings.getKilobyte();
-        byte[] blockArr = new byte[blockSize];
-        for (int b = 0; b < blockArr.length; b++) {
-            if (b % 2 == 0) {
-                blockArr[b] = (byte) 0xFF;
-            }
-        }
-
-        DiskMark wMark, rMark;  // declare vars that will point to objects used to pass progress to UI
 
         ui.updateLegend();  // init chart legend info
 
@@ -57,109 +29,17 @@ public class GeneralUsageBenchmarker implements Benchmarker {
             ui.resetTestData();
         }
 
-        int startFileNum = settings.getNextMarkNumber();
+        MyInvoker simpleExecutor = new MyInvoker();
+
+
 
         /*
           The GUI allows a Write, Read, or both types of BMs to be started. They are done serially.
          */
         if (settings.isWriteTest()) {
-            DiskRun run = new DiskRun(DiskRun.IOMode.WRITE, settings.getBlockSequence());
-            run.setNumMarks(settings.getNumOfMarks());
-            run.setNumBlocks(settings.getNumOfBlocks());
-            run.setBlockSize(settings.getBlockSizeKb());
-            run.setTxSize(settings.getTargetTxSizeKb());
-            run.setDiskInfo(Util.getDiskInfo(settings.getDataDir()));
-
-            // Tell logger and GUI to display what we know so far about the Run
-            settings.message("disk info: (" + run.getDiskInfo() + ")");
-
-            ui.updateTitle(run.getDiskInfo());
-
-            // Create a test data file using the default file system and config-specified location
-            if (!settings.isMultiFile()) {
-                testFile = new File(settings.getDataDir().getAbsolutePath() + File.separator + "testdata.jdm");
-            }
-
-            /*
-              Begin an outer loop for specified duration (number of 'marks') of benchmark,
-              that keeps writing data (in its own loop - for specified # of blocks). Each 'Mark' is timed
-              and is reported to the GUI for display as each Mark completes.
-             */
-            for (int m = startFileNum; m < startFileNum + settings.getNumOfMarks() && !worker.isCancelledFromOutside(); m++) {
-
-                if (settings.isMultiFile()) {
-                    testFile = new File(settings.getDataDir().getAbsolutePath()
-                            + File.separator + "testdata" + m + ".jdm");
-                }
-                wMark = new DiskMark(WRITE);    // starting to keep track of a new benchmark
-                wMark.setMarkNum(m);
-                long startTime = System.nanoTime();
-                long totalBytesWrittenInMark = 0;
-
-                String mode = "rw";
-                if (settings.isWriteSyncEnabled()) {
-                    mode = "rwd";
-                }
-
-                try {
-                    try (RandomAccessFile rAccFile = new RandomAccessFile(testFile, mode)) {
-                        for (int b = 0; b < settings.getNumOfBlocks(); b++) {
-                            if (settings.getBlockSequence() == DiskRun.BlockSequence.RANDOM) {
-                                int rLoc = Util.randInt(0, settings.getNumOfBlocks() - 1);
-                                rAccFile.seek((long) rLoc * blockSize);
-                            } else {
-                                rAccFile.seek((long) b * blockSize);
-                            }
-                            rAccFile.write(blockArr, 0, blockSize);
-                            totalBytesWrittenInMark += blockSize;
-                            wUnitsComplete++;
-                            unitsComplete = rUnitsComplete + wUnitsComplete;
-                            percentComplete = (float) unitsComplete / (float) unitsTotal * 100f;
-
-                            /*
-                              Report to GUI what percentage level of Entire BM (#Marks * #Blocks) is done.
-                             */
-                            worker.setProgressFromOutside((int) percentComplete);
-                        }
-                    }
-                } catch (IOException ex) {
-                    Logger.getLogger(DiskWorker.class.getName()).log(Level.SEVERE, null, ex);
-                }
-
-                /*
-                  Compute duration, throughput of this Mark's step of BM
-                 */
-                long endTime = System.nanoTime();
-                long elapsedTimeNs = endTime - startTime;
-                double sec = (double) elapsedTimeNs / (double) 1000000000;
-                double mbWritten = (double) totalBytesWrittenInMark / (double) settings.getMegabyte();
-                wMark.setBwMbSec(mbWritten / sec);
-                settings.message("m:" + m + " write IO is " + wMark.getBwMbSecAsString() + " MB/s     "
-                        + "(" + Util.displayString(mbWritten) + "MB written in "
-                        + Util.displayString(sec) + " sec)");
-                settings.updateMetrics(wMark);
-
-                /*
-                  Let the GUI know the interim result described by the current Mark
-                 */
-                worker.publishFromOutside(wMark);
-
-                // Keep track of statistics to be displayed and persisted after all Marks are done.
-                run.setRunMax(wMark.getCumMax());
-                run.setRunMin(wMark.getCumMin());
-                run.setRunAvg(wMark.getCumAvg());
-                run.setEndTime(new Date());
-            } // END outer loop for specified duration (number of 'marks') for WRITE benchmark
-
-            /*
-              Persist info about the Write BM Run (e.g. into Derby Database) and add it to a GUI panel
-             */
-            EntityManager em = EM.getEntityManager();
-            em.getTransaction().begin();
-            em.persist(run);
-            em.getTransaction().commit();
-
-            ui.addRun(run);
+            WriteBenchMarkCommandReceiver writeReceiver = new WriteBenchMarkCommandReceiver();
+            WriteBenchmarkCommand writeCommand = new WriteBenchmarkCommand(settings,ui,worker, writeReceiver);
+            simpleExecutor.submit(writeCommand);
         }
 
         /*
@@ -182,79 +62,12 @@ public class GeneralUsageBenchmarker implements Benchmarker {
 
         // Same as above, just for Read operations instead of Writes.
         if (settings.isReadTest()) {
-            DiskRun run = new DiskRun(DiskRun.IOMode.READ, settings.getBlockSequence());
-            run.setNumMarks(settings.getNumOfMarks());
-            run.setNumBlocks(settings.getNumOfBlocks());
-            run.setBlockSize(settings.getBlockSizeKb());
-            run.setTxSize(settings.getTargetTxSizeKb());
-            run.setDiskInfo(Util.getDiskInfo(settings.getDataDir()));
-
-            settings.message("disk info: (" + run.getDiskInfo() + ")");
-
-            ui.updateTitle(run.getDiskInfo());
-
-            for (int m = startFileNum; m < startFileNum + settings.getNumOfMarks() && !worker.isCancelledFromOutside(); m++) {
-
-                if (settings.isMultiFile()) {
-                    testFile = new File(settings.getDataDir().getAbsolutePath()
-                            + File.separator + "testdata" + m + ".jdm");
-                }
-                rMark = new DiskMark(READ);  // starting to keep track of a new benchmark
-                rMark.setMarkNum(m);
-                long startTime = System.nanoTime();
-                long totalBytesReadInMark = 0;
-
-                try {
-                    try (RandomAccessFile rAccFile = new RandomAccessFile(testFile, "r")) {
-                        for (int b = 0; b < settings.getNumOfBlocks(); b++) {
-                            if (settings.getBlockSequence() == DiskRun.BlockSequence.RANDOM) {
-                                int rLoc = Util.randInt(0, settings.getNumOfBlocks() - 1);
-                                rAccFile.seek((long) rLoc * blockSize);
-                            } else {
-                                rAccFile.seek((long) b * blockSize);
-                            }
-                            rAccFile.readFully(blockArr, 0, blockSize);
-                            totalBytesReadInMark += blockSize;
-                            rUnitsComplete++;
-                            unitsComplete = rUnitsComplete + wUnitsComplete;
-                            percentComplete = (float) unitsComplete / (float) unitsTotal * 100f;
-                            worker.setProgressFromOutside((int) percentComplete);
-                        }
-                    }
-                } catch (FileNotFoundException ex) {
-                    Logger.getLogger(DiskWorker.class.getName()).log(Level.SEVERE, null, ex);
-                    String emsg = "May not have done Write Benchmarks, so no data available to read." +
-                            ex.getMessage();
-                    ui.showErrorMessageDialog(emsg, "Unable to READ");
-                    settings.message(emsg);
-                    return false;
-                }
-                long endTime = System.nanoTime();
-                long elapsedTimeNs = endTime - startTime;
-                double sec = (double) elapsedTimeNs / (double) 1000000000;
-                double mbRead = (double) totalBytesReadInMark / (double) settings.getMegabyte();
-                rMark.setBwMbSec(mbRead / sec);
-                settings.message("m:" + m + " READ IO is " + rMark.getBwMbSec() + " MB/s    "
-                        + "(MBread " + mbRead + " in " + sec + " sec)");
-                settings.updateMetrics(rMark);
-                worker.publishFromOutside(rMark);
-
-                run.setRunMax(rMark.getCumMax());
-                run.setRunMin(rMark.getCumMin());
-                run.setRunAvg(rMark.getCumAvg());
-                run.setEndTime(new Date());
-            }
-
-            /*
-              Persist info about the Read BM Run (e.g. into Derby Database) and add it to a GUI panel
-             */
-            EntityManager em = EM.getEntityManager();
-            em.getTransaction().begin();
-            em.persist(run);
-            em.getTransaction().commit();
-
-            ui.addRun(run);
+            ReadBenchmarkCommandReceiver readReceiver = new ReadBenchmarkCommandReceiver();
+            ReadBenchmarkCommand readCommand = new ReadBenchmarkCommand(settings,ui, worker, readReceiver);
+            simpleExecutor.submit(readCommand);
         }
+
+        simpleExecutor.runAll();
         settings.incrementNextMarkNumber();
         return true;
     }

--- a/lib/src/main/java/edu/touro/mco152/bm/commands/CommandInterface.java
+++ b/lib/src/main/java/edu/touro/mco152/bm/commands/CommandInterface.java
@@ -1,0 +1,7 @@
+package edu.touro.mco152.bm.commands;
+/**
+ * Command interface representing a single, executable benchmarking action request
+ */
+public interface CommandInterface {
+    void execute()throws Exception;
+}

--- a/lib/src/main/java/edu/touro/mco152/bm/commands/MyInvoker.java
+++ b/lib/src/main/java/edu/touro/mco152/bm/commands/MyInvoker.java
@@ -1,0 +1,22 @@
+package edu.touro.mco152.bm.commands;
+
+import java.util.LinkedList;
+import java.util.Queue;
+
+/**
+ * Simple serial executor that queues and runs submitted commands one by one.
+ */
+public class MyInvoker {
+    Queue<CommandInterface> queue = new LinkedList<>();
+
+    public void submit(CommandInterface command){
+        queue.offer(command);
+    }
+
+    public void runAll()throws Exception{
+        while(!queue.isEmpty()){
+            CommandInterface command = queue.poll();
+            command.execute();
+        }
+    }
+}

--- a/lib/src/main/java/edu/touro/mco152/bm/commands/ReadBenchmarkCommand.java
+++ b/lib/src/main/java/edu/touro/mco152/bm/commands/ReadBenchmarkCommand.java
@@ -1,0 +1,30 @@
+package edu.touro.mco152.bm.commands;
+
+
+import edu.touro.mco152.bm.BenchmarkSettings;
+import edu.touro.mco152.bm.DiskWorker;
+import edu.touro.mco152.bm.GeneralUI;
+/**
+ * Executes a read benchmark by delegating to its receiver.
+ */
+public class ReadBenchmarkCommand implements CommandInterface{
+
+    private final BenchmarkSettings settings;
+    private final GeneralUI ui;
+    private final DiskWorker worker;
+    private final ReadBenchmarkCommandReceiver receiver;
+
+    public ReadBenchmarkCommand(BenchmarkSettings settings, GeneralUI ui, DiskWorker worker, ReadBenchmarkCommandReceiver receiver){
+        this.settings = settings;
+        this.ui = ui;
+        this.worker = worker;
+        this.receiver = receiver;
+
+    }
+
+    @Override
+    public void execute(){
+        int newNext = receiver.doRead(settings, ui, worker);
+        settings.setNextMarkNumber(newNext);
+    }
+}

--- a/lib/src/main/java/edu/touro/mco152/bm/commands/ReadBenchmarkCommandReceiver.java
+++ b/lib/src/main/java/edu/touro/mco152/bm/commands/ReadBenchmarkCommandReceiver.java
@@ -1,0 +1,121 @@
+package edu.touro.mco152.bm.commands;
+
+import edu.touro.mco152.bm.*;
+import edu.touro.mco152.bm.persist.DiskRun;
+import edu.touro.mco152.bm.persist.EM;
+import edu.touro.mco152.bm.DiskMark;
+import jakarta.persistence.EntityManager;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.util.Date;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import static edu.touro.mco152.bm.DiskMark.MarkType.READ;
+/**
+ * Contains the logic to perform a read‐only disk benchmark to become a command object
+ */
+public class ReadBenchmarkCommandReceiver {
+    public int doRead(BenchmarkSettings settings, GeneralUI ui, DiskWorker worker){
+        int wUnitsComplete = 0, rUnitsComplete = 0, unitsComplete;
+        int wUnitsTotal = settings.isWriteTest() ? settings.getNumOfBlocks() * settings.getNumOfMarks() : 0;
+        int rUnitsTotal = settings.isReadTest() ? settings.getNumOfBlocks() * settings.getNumOfMarks() : 0;
+        int unitsTotal = wUnitsTotal + rUnitsTotal;
+        float percentComplete;
+
+        int blockSize = settings.getBlockSizeKb() * settings.getKilobyte();
+        byte[] blockArr = new byte[blockSize];
+        for (int b = 0; b < blockArr.length; b++) {
+            if (b % 2 == 0) {
+                blockArr[b] = (byte) 0xFF;
+            }
+        }
+
+        DiskMark rMark;
+
+        int startFileNum = settings.getNextMarkNumber();
+
+
+        DiskRun run = new DiskRun(DiskRun.IOMode.READ, settings.getBlockSequence());
+        run.setNumMarks(settings.getNumOfMarks());
+        run.setNumBlocks(settings.getNumOfBlocks());
+        run.setBlockSize(settings.getBlockSizeKb());
+        run.setTxSize(settings.getTargetTxSizeKb());
+        run.setDiskInfo(Util.getDiskInfo(settings.getDataDir()));
+
+        settings.message("disk info: (" + run.getDiskInfo() + ")");
+
+        ui.updateTitle(run.getDiskInfo());
+
+        File testFile = null;
+        for (int m = startFileNum; m < startFileNum + settings.getNumOfMarks() && !worker.isCancelledFromOutside(); m++) {
+
+            if (settings.isMultiFile()) {
+                testFile = new File(settings.getDataDir().getAbsolutePath()
+                        + File.separator + "testdata" + m + ".jdm");
+            }
+            rMark = new DiskMark(READ);  // starting to keep track of a new benchmark
+            rMark.setMarkNum(m);
+            long startTime = System.nanoTime();
+            long totalBytesReadInMark = 0;
+
+            try {
+                try (RandomAccessFile rAccFile = new RandomAccessFile(testFile, "r")) {
+                    for (int b = 0; b < settings.getNumOfBlocks(); b++) {
+                        if (settings.getBlockSequence() == DiskRun.BlockSequence.RANDOM) {
+                            int rLoc = Util.randInt(0, settings.getNumOfBlocks() - 1);
+                            rAccFile.seek((long) rLoc * blockSize);
+                        } else {
+                            rAccFile.seek((long) b * blockSize);
+                        }
+                        rAccFile.readFully(blockArr, 0, blockSize);
+                        totalBytesReadInMark += blockSize;
+                        rUnitsComplete++;
+                        unitsComplete = rUnitsComplete + wUnitsComplete;
+                        percentComplete = (float) unitsComplete / (float) unitsTotal * 100f;
+                        worker.setProgressFromOutside((int) percentComplete);
+                    }
+                }
+            } catch (IOException ex) {
+                Logger.getLogger(DiskWorker.class.getName()).log(Level.SEVERE, null, ex);
+                String emsg = "May not have done Write Benchmarks, so no data available to read." +
+                        ex.getMessage();
+                ui.showErrorMessageDialog(emsg, "Unable to READ");
+                settings.message(emsg);
+                return startFileNum;
+            }
+            long endTime = System.nanoTime();
+            long elapsedTimeNs = endTime - startTime;
+            double sec = (double) elapsedTimeNs / (double) 1000000000;
+            double mbRead = (double) totalBytesReadInMark / (double) settings.getMegabyte();
+            rMark.setBwMbSec(mbRead / sec);
+            settings.message("m:" + m + " READ IO is " + rMark.getBwMbSec() + " MB/s    "
+                    + "(MBread " + mbRead + " in " + sec + " sec)");
+            settings.updateMetrics(rMark);
+            worker.publishFromOutside(rMark);
+
+            run.setRunMax(rMark.getCumMax());
+            run.setRunMin(rMark.getCumMin());
+            run.setRunAvg(rMark.getCumAvg());
+            run.setEndTime(new Date());
+        }
+
+            /*
+              Persist info about the Read BM Run (e.g. into Derby Database) and add it to a GUI panel
+             */
+        try {
+            EntityManager em = EM.getEntityManager();
+            em.getTransaction().begin();
+            em.persist(run);
+            em.getTransaction().commit();
+
+            ui.addRun(run);
+        } catch (Exception e) {
+
+        }
+
+        return startFileNum + settings.getNumOfMarks();
+    }
+}

--- a/lib/src/main/java/edu/touro/mco152/bm/commands/WriteBenchMarkCommandReceiver.java
+++ b/lib/src/main/java/edu/touro/mco152/bm/commands/WriteBenchMarkCommandReceiver.java
@@ -1,0 +1,145 @@
+package edu.touro.mco152.bm.commands;
+
+import edu.touro.mco152.bm.*;
+import edu.touro.mco152.bm.persist.DiskRun;
+import edu.touro.mco152.bm.DiskMark;
+import edu.touro.mco152.bm.persist.EM;
+import jakarta.persistence.EntityManager;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.util.Date;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import static edu.touro.mco152.bm.DiskMark.MarkType.WRITE;
+/**
+ * Contains the logic to perform a write‐only disk benchmark action to become our command
+ */
+public class WriteBenchMarkCommandReceiver {
+    public int doWrite(BenchmarkSettings settings, GeneralUI ui, DiskWorker worker){
+        int wUnitsComplete = 0, rUnitsComplete = 0, unitsComplete;
+        int wUnitsTotal = settings.isWriteTest() ? settings.getNumOfBlocks() * settings.getNumOfMarks() : 0;
+        int rUnitsTotal = settings.isReadTest() ? settings.getNumOfBlocks() * settings.getNumOfMarks() : 0;
+        int unitsTotal = wUnitsTotal + rUnitsTotal;
+        float percentComplete;
+
+        int blockSize = settings.getBlockSizeKb() * settings.getKilobyte();
+        byte[] blockArr = new byte[blockSize];
+        for (int b = 0; b < blockArr.length; b++) {
+            if (b % 2 == 0) {
+                blockArr[b] = (byte) 0xFF;
+            }
+        }
+
+        DiskMark wMark;
+
+        int startFileNum = settings.getNextMarkNumber();
+
+        DiskRun run = new DiskRun(DiskRun.IOMode.WRITE, settings.getBlockSequence());
+        run.setNumMarks(settings.getNumOfMarks());
+        run.setNumBlocks(settings.getNumOfBlocks());
+        run.setBlockSize(settings.getBlockSizeKb());
+        run.setTxSize(settings.getTargetTxSizeKb());
+        run.setDiskInfo(Util.getDiskInfo(settings.getDataDir()));
+
+        // Tell logger and GUI to display what we know so far about the Run
+        settings.message("disk info: (" + run.getDiskInfo() + ")");
+
+        ui.updateTitle(run.getDiskInfo());
+
+        // Create a test data file using the default file system and config-specified location
+        File testFile = null;
+        if (!settings.isMultiFile()) {
+            testFile = new File(settings.getDataDir().getAbsolutePath() + File.separator + "testdata.jdm");
+        }
+
+            /*
+              Begin an outer loop for specified duration (number of 'marks') of benchmark,
+              that keeps writing data (in its own loop - for specified # of blocks). Each 'Mark' is timed
+              and is reported to the GUI for display as each Mark completes.
+             */
+        for (int m = startFileNum; m < startFileNum + settings.getNumOfMarks() && !worker.isCancelledFromOutside(); m++) {
+
+            if (settings.isMultiFile()) {
+                testFile = new File(settings.getDataDir().getAbsolutePath()
+                        + File.separator + "testdata" + m + ".jdm");
+            }
+            wMark = new DiskMark(WRITE);    // starting to keep track of a new benchmark
+            wMark.setMarkNum(m);
+            long startTime = System.nanoTime();
+            long totalBytesWrittenInMark = 0;
+
+            String mode = "rw";
+            if (settings.isWriteSyncEnabled()) {
+                mode = "rwd";
+            }
+
+            try {
+                try (RandomAccessFile rAccFile = new RandomAccessFile(testFile, mode)) {
+                    for (int b = 0; b < settings.getNumOfBlocks(); b++) {
+                        if (settings.getBlockSequence() == DiskRun.BlockSequence.RANDOM) {
+                            int rLoc = Util.randInt(0, settings.getNumOfBlocks() - 1);
+                            rAccFile.seek((long) rLoc * blockSize);
+                        } else {
+                            rAccFile.seek((long) b * blockSize);
+                        }
+                        rAccFile.write(blockArr, 0, blockSize);
+                        totalBytesWrittenInMark += blockSize;
+                        wUnitsComplete++;
+                        unitsComplete = rUnitsComplete + wUnitsComplete;
+                        percentComplete = (float) unitsComplete / (float) unitsTotal * 100f;
+
+                            /*
+                              Report to GUI what percentage level of Entire BM (#Marks * #Blocks) is done.
+                             */
+                        worker.setProgressFromOutside((int) percentComplete);
+                    }
+                }
+            } catch (IOException ex) {
+                Logger.getLogger(DiskWorker.class.getName()).log(Level.SEVERE, null, ex);
+            }
+
+                /*
+                  Compute duration, throughput of this Mark's step of BM
+                 */
+            long endTime = System.nanoTime();
+            long elapsedTimeNs = endTime - startTime;
+            double sec = (double) elapsedTimeNs / (double) 1000000000;
+            double mbWritten = (double) totalBytesWrittenInMark / (double) settings.getMegabyte();
+            wMark.setBwMbSec(mbWritten / sec);
+            settings.message("m:" + m + " write IO is " + wMark.getBwMbSecAsString() + " MB/s     "
+                    + "(" + Util.displayString(mbWritten) + "MB written in "
+                    + Util.displayString(sec) + " sec)");
+            settings.updateMetrics(wMark);
+
+                /*
+                  Let the GUI know the interim result described by the current Mark
+                 */
+            worker.publishFromOutside(wMark);
+
+            // Keep track of statistics to be displayed and persisted after all Marks are done.
+            run.setRunMax(wMark.getCumMax());
+            run.setRunMin(wMark.getCumMin());
+            run.setRunAvg(wMark.getCumAvg());
+            run.setEndTime(new Date());
+        } // END outer loop for specified duration (number of 'marks') for WRITE benchmark
+
+            /*
+              Persist info about the Write BM Run (e.g. into Derby Database) and add it to a GUI panel
+             */
+        try {
+            EntityManager em = EM.getEntityManager();
+            em.getTransaction().begin();
+            em.persist(run);
+            em.getTransaction().commit();
+
+            ui.addRun(run);
+        } catch (Exception e) {
+
+        }
+
+        return startFileNum + settings.getNumOfMarks();
+    }
+}

--- a/lib/src/main/java/edu/touro/mco152/bm/commands/WriteBenchmarkCommand.java
+++ b/lib/src/main/java/edu/touro/mco152/bm/commands/WriteBenchmarkCommand.java
@@ -1,0 +1,35 @@
+package edu.touro.mco152.bm.commands;
+
+import edu.touro.mco152.bm.BenchmarkSettings;
+import edu.touro.mco152.bm.DiskWorker;
+import edu.touro.mco152.bm.GeneralUI;
+
+/**
+ * A ConcreteCommand that wraps WriteBenchMarkCommandReceiver.
+ * Its execute() method calls receiver.doWrite(...) and then updates settings.nextMarkNumber.
+ */
+public class WriteBenchmarkCommand implements CommandInterface {
+
+    private final BenchmarkSettings settings;
+    private final GeneralUI ui;
+    private final DiskWorker worker;
+    private final WriteBenchMarkCommandReceiver receiver;
+
+    public WriteBenchmarkCommand(
+            BenchmarkSettings settings,
+            GeneralUI ui,
+            DiskWorker worker,
+            WriteBenchMarkCommandReceiver receiver
+    ) {
+        this.settings = settings;
+        this.ui = ui;
+        this.worker = worker;
+        this.receiver = receiver;
+    }
+
+    @Override
+    public void execute() throws Exception {
+        int newNext = receiver.doWrite(settings, ui, worker);
+        settings.setNextMarkNumber(newNext);
+    }
+}

--- a/lib/src/main/java/edu/touro/mco152/bm/ui/ConsoleUI.java
+++ b/lib/src/main/java/edu/touro/mco152/bm/ui/ConsoleUI.java
@@ -1,0 +1,72 @@
+package edu.touro.mco152.bm.ui;
+
+import edu.touro.mco152.bm.DiskMark;
+import edu.touro.mco152.bm.GeneralUI;
+import edu.touro.mco152.bm.persist.DiskRun;
+
+/**
+ * A minimal, non‑Swing implementation of GeneralUI for command‐pattern tests.
+ * • Counts how many read marks have been reported.
+ * • All other methods are no‑ops.
+ */
+public class ConsoleUI implements GeneralUI {
+
+    private int readMarksCount = 0;
+
+    /**
+     * Returns how many times addReadMark(...) was called.
+     */
+    public int readMarksCount() {
+        return readMarksCount;
+    }
+
+    // ───────────────────────────────────────────────────────────────────────────────────
+    // Implement exactly the methods declared in your  GeneralUI.
+    // Everything is a no‑op except addReadMark increments our counter for testing.
+    // ───────────────────────────────────────────────────────────────────────────────────
+
+    @Override
+    public void updateLegend() {
+        // no‑op
+    }
+
+    @Override
+    public void resetTestData() {
+        // no‑op
+    }
+
+    @Override
+    public void addWriteMark(DiskMark mark) {
+        // no‑op for write marks
+    }
+
+    @Override
+    public void addReadMark(DiskMark mark) {
+        readMarksCount++;
+    }
+
+    @Override
+    public void updateTitle(String text) {
+        // no‑op
+    }
+
+    @Override
+    public void adjustSensitivity() {
+        // no‑op
+    }
+
+    @Override
+    public void showPlainMessageDialog(String message, String title) {
+        // no‑op
+    }
+
+    @Override
+    public void showErrorMessageDialog(String message, String title) {
+        // no‑op
+    }
+
+    @Override
+    public void addRun(DiskRun run) {
+        // no‑op
+    }
+}

--- a/lib/src/test/java/edu/touro/mco152/bm/CommandPatternTests.java
+++ b/lib/src/test/java/edu/touro/mco152/bm/CommandPatternTests.java
@@ -1,0 +1,197 @@
+// File: src/test/java/edu/touro/mco152/bm/CommandPatternTests.java
+
+package edu.touro.mco152.bm;
+
+import edu.touro.mco152.bm.commands.ReadBenchmarkCommand;
+import edu.touro.mco152.bm.commands.ReadBenchmarkCommandReceiver;
+import edu.touro.mco152.bm.commands.WriteBenchMarkCommandReceiver;
+import edu.touro.mco152.bm.commands.WriteBenchmarkCommand;
+import edu.touro.mco152.bm.persist.DiskRun;
+import edu.touro.mco152.bm.ui.ConsoleUI;
+import edu.touro.mco152.bm.ui.Gui;
+import edu.touro.mco152.bm.ui.MainFrame;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.util.Properties;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class CommandPatternTests {
+
+    private File tempDir;
+
+    /**
+     * (1)  The bruteforce setUp that Prof. provided in the previous BadBM assignment.
+     */
+    private static void setupDefaultAsPerProperties() {
+        Gui.mainFrame = new MainFrame();
+
+        App.p = new Properties();
+        App.loadConfig();
+
+        Gui.progressBar = Gui.mainFrame.getProgressBar();
+        System.setProperty("derby.system.home", App.APP_CACHE_DIR);
+
+        if (App.locationDir == null) {
+            App.locationDir = new File(System.getProperty("user.home"));
+        }
+        App.dataDir = new File(App.locationDir.getAbsolutePath() + File.separator + App.DATADIRNAME);
+
+        if (App.dataDir.exists()) {
+            App.dataDir.delete();
+        }
+        App.dataDir.mkdirs();
+    }
+
+    @BeforeEach
+    void setUp() {
+        setupDefaultAsPerProperties();
+
+        tempDir = new File(System.getProperty("java.io.tmpdir"), "badbm_test_" + System.nanoTime());
+        tempDir.mkdirs();
+        App.dataDir = tempDir;
+
+        App.numOfMarks    = 25;
+        App.numOfBlocks   = 128;
+        App.blockSizeKb   = 2048;
+        App.blockSequence = DiskRun.BlockSequence.SEQUENTIAL;
+
+        App.nextMarkNumber = 0;
+    }
+
+    @AfterEach
+    void tearDown() {
+        deleteRecursively(tempDir);
+    }
+
+    private void deleteRecursively(File f) {
+        if (f.isDirectory()) {
+            for (File child : f.listFiles()) {
+                deleteRecursively(child);
+            }
+        }
+        f.delete();
+    }
+
+    private static class StubWorker extends DiskWorker {
+        private final GeneralUI ui;
+
+        StubWorker(BenchmarkSettings settings, GeneralUI ui) {
+            // pass dummy benchmarker; we never call doInBackground()
+            super(settings, ui, (s, u, w) -> true);
+            this.ui = ui;
+        }
+
+        @Override
+        public void publishFromOutside(DiskMark mark) {
+            // As soon as doWrite()/doRead() calls worker.publishFromOutside(mark),
+            // immediately forward that DiskMark to ui.
+            ui.addWriteMark(mark);
+            ui.addReadMark(mark);
+        }
+
+        @Override
+        public boolean isCancelledFromOutside() {
+            return false;
+        }
+
+        @Override
+        public void setProgressFromOutside(int percent) {
+            // no‐op in tests
+        }
+    }
+
+    /**
+    Verify 25 files exist and are the correct size; nextMarkNumber should be 25.
+     */
+    @Test
+    public void testWriteBenchmarkCommand() throws Exception {
+        // ===== 1) Turn “on” write, “off” read =====
+        App.writeTest = true;
+        App.readTest  = false;
+
+        // ===== 2) Build basic settings UI and worker to pass =====
+        BenchmarkSettings settings = new AppBenchmarkSettings();
+        ConsoleUI ui = new ConsoleUI();
+        StubWorker       worker   = new StubWorker(settings, ui);
+
+        // ===== 4) Create and run the Write command =====
+        WriteBenchMarkCommandReceiver receiver = new WriteBenchMarkCommandReceiver();
+        WriteBenchmarkCommand writeCmd = new WriteBenchmarkCommand(settings, ui, worker, receiver);
+
+        writeCmd.execute();  // ← running should create 25 files
+
+        // ===== 5) After execute, nextMarkNumber must be 25 =====
+        assertEquals(25, settings.getNextMarkNumber());
+
+        // ===== 6) Verify exactly 25 files named testdata0.jdm … testdata24.jdm exist & are correct size =====
+        long expectedSize = 128L * 2048L * 1024L;  // 128 blocks × 2048KB × 1024 bytes
+        for (int i = 0; i < 25; i++) {
+            File f = new File(tempDir, "testdata" + i + ".jdm");
+            assertTrue(f.exists(), "Expected file: " + f.getName());
+            assertEquals(expectedSize, f.length());
+        }
+    }
+
+    /**
+     Verify nextMarkNumber is 25 and ConsoleUI saw exactly 25 addReadMark(...) calls.
+     */
+    @Test
+    public void testReadBenchmarkCommand() throws Exception {
+        // --- STEP A) Build & run Write pass first so files exist ---
+        App.writeTest = true;
+        App.readTest  = false;
+
+        BenchmarkSettings writeSettings = new AppBenchmarkSettings();
+        ConsoleUI writeUI = new ConsoleUI();
+
+        StubWorker       writeWorker   = new StubWorker(writeSettings, writeUI);
+
+        WriteBenchMarkCommandReceiver wrReceiver = new WriteBenchMarkCommandReceiver();
+        WriteBenchmarkCommand wrCmd = new WriteBenchmarkCommand(writeSettings, writeUI, writeWorker, wrReceiver);
+
+        wrCmd.execute();  // ← now 25 files exist
+
+        // sanity‐check that files exist
+        for (int i = 0; i < 25; i++) {
+            File f = new File(tempDir, "testdata" + i + ".jdm");
+            assertTrue(f.exists());
+        }
+
+        // Reset nextMarkNumber back to 0 so read will start at testdata0.jdm again
+        writeSettings.setNextMarkNumber(0);
+
+        // --- STEP B) Now do the Read ---
+        App.writeTest = false;
+        App.readTest  = true;
+
+        BenchmarkSettings readSettings = new AppBenchmarkSettings();
+        ConsoleUI readUI = new ConsoleUI();
+
+        DiskWorker readWorker = new DiskWorker(readSettings, readUI, new GeneralUsageBenchmarker()) {
+            @Override
+            public void publishFromOutside(DiskMark mark) {
+                // Immediately forward to addReadMark(mark) so we get a count
+                readUI.addReadMark(mark);
+            }
+            @Override
+            public void setProgressFromOutside(int percent) { }
+            @Override
+            public boolean isCancelledFromOutside() { return false; }
+        };
+
+        ReadBenchmarkCommandReceiver rdReceiver = new ReadBenchmarkCommandReceiver();
+        ReadBenchmarkCommand rdCmd = new ReadBenchmarkCommand(readSettings, readUI, readWorker, rdReceiver);
+
+        rdCmd.execute();  // ← should loop exactly 25 times
+
+        // --- STEP C) nextMarkNumber must be 25 now ---
+        assertEquals(25, readSettings.getNextMarkNumber());
+
+        // --- STEP D) ConsoleUI must have seen 25 calls to addReadMark(...) ---
+        assertEquals(25, readUI.readMarksCount());
+    }
+}


### PR DESCRIPTION
This PR refactors DiskWorker to use a Command‐Pattern approach and introduces a simple serial executor (MyInvoker).

• DiskWorker now delegates to GeneralUsageBenchmarker, which submits WriteBenchmarkCommand or ReadBenchmarkCommand (based on settings).  
• WriteBenchmarkCommand & ReadBenchmarkCommand wrap their respective CommandReceiver classes.  
• WriteBenchMarkCommandReceiver and ReadBenchmarkCommandReceiver encapsulate the former write/read loops from DiskWorker.  
• MyInvoker is a simple FIFO executor that runs queued commands in order.  
• Added ConsoleUI as a headless GeneralUI implementation.  
• Added CommandPatternTests which verify write and read benchmarks run correctly without Swing.